### PR TITLE
Make conversion a little more forgiving

### DIFF
--- a/src/parse/param.js
+++ b/src/parse/param.js
@@ -2,22 +2,30 @@ const { isString } = require('../aid')
 
 function param(node, spec) {
   const item = {}
+
   if (isString(node.value)) {
     item.value = node.value
   }
+
   if (node.fileName) {
     item.fileName = node.fileName
   }
+
   if (node.contentType) {
     item.type = node.contentType
   }
+
   if (node.comment) {
     item.comment = node.comment
   }
-  if (!spec.has(node.name)) {
-    spec.set(node.name, new Set())
+
+  if (node.name) {
+    if (!spec.has(node.name)) {
+      spec.set(node.name, new Set())
+    }
+
+    spec.get(node.name).add(item)
   }
-  spec.get(node.name).add(item)
 }
 
 module.exports = param

--- a/src/validate/param.js
+++ b/src/validate/param.js
@@ -14,7 +14,7 @@ function param(node, i, j) {
 
 function validate(node, i, j) {
   if (empty(node.name)) {
-    throw new InvalidArchiveError({ name: 'MissingParamName' }, `Missing param name (${i}:${j})`)
+    console.warn(`[WARN] Discarding param with missing name (${i}:${j})`)
   }
   if (typeof node.name !== 'string') {
     throw new InvalidArchiveError(

--- a/src/validate/postData.js
+++ b/src/validate/postData.js
@@ -1,5 +1,10 @@
 const params = require('./params')
-const { empty, emptyObject, seralizeURLSearchParams, getContentTypeValue } = require('../aid')
+const {
+  empty,
+  emptyObject,
+  seralizeURLSearchParams,
+  getContentTypeValue,
+} = require('../aid')
 const { InvalidArchiveError } = require('../error')
 
 /*
@@ -63,9 +68,8 @@ function validate(node, i) {
     node.mimeType.includes('application/x-www-form-urlencoded')
   ) {
     if (seralizeURLSearchParams(node.params) !== node.text) {
-      throw new InvalidArchiveError(
-        { name: 'PostDataConflict' },
-        `Post data conflict (${i}): params and text must be equal if both are provided`
+      console.warn(
+        `[WARN] Post data conflict (${i}): Both params and text are provided but the values do not match.`
       )
     }
   }

--- a/test/unit/validate/param.js
+++ b/test/unit/validate/param.js
@@ -2,15 +2,6 @@ import test from 'ava'
 import param from 'validate/param'
 import { assay as makeAssay } from 'make'
 
-test('missing name', (t) => {
-  t.throws(
-    () => {
-      param({}, 0, 0, makeAssay())
-    },
-    { name: 'MissingParamName' }
-  )
-})
-
 test('invalid name', (t) => {
   t.throws(
     () => {

--- a/test/unit/validate/postData.js
+++ b/test/unit/validate/postData.js
@@ -1,7 +1,9 @@
 import test from 'ava'
 import isolate from 'helper/isolate'
 import { assay as makeAssay } from 'make'
-const [postData, { params }] = isolate(test, 'validate/postData', { params: 'validate/params' })
+const [postData, { params }] = isolate(test, 'validate/postData', {
+  params: 'validate/params',
+})
 
 test.serial('empty', (t) => {
   t.notThrows(() => {
@@ -67,23 +69,6 @@ test.serial('invalid structured type', (t) => {
       )
     },
     { name: 'InvalidPostDataType' }
-  )
-})
-
-test.serial('invalid postData combination', (t) => {
-  t.throws(
-    () => {
-      postData(
-        {
-          mimeType: 'application/x-www-form-urlencoded',
-          params: [{ name: 'foo', value: 1 }],
-          text: 'bar=2',
-        },
-        0,
-        makeAssay()
-      )
-    },
-    { name: 'PostDataConflict' }
   )
 })
 


### PR DESCRIPTION
- Incoming postData param with empty names are discarded with a warning log message. 
- Dropping text with a warning log if both postData text and params are specified and are conflicting.