### PR TITLE
[fix] Don't re-encode POST data unless it is necessary

### DIFF
--- a/src/parse/postData.js
+++ b/src/parse/postData.js
@@ -3,11 +3,11 @@ const params = require('./params')
 function postData(node, spec) {
   spec.type = node.mimeType
 
-  if (node.params && node.params.length) {
+  if (node.text) {
+    spec.value = node.text
+  } else if (node.params && node.params.length) {
     spec.params = new Map()
     params(node.params, spec.params)
-  } else if (node.text) {
-    spec.value = node.text
   }
 
   if (node.comment) {


### PR DESCRIPTION
If postData contains the posted text, preferentially use it instead of re-encoding the formData from postData.params.

Created as a partial fix for https://github.com/loadimpact/har-to-k6/issues/56