### PR TITLE
ci: Disable dependency pinning for renovate and limit it to security updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [":preserveSemverRanges", "security:only-security-updates"]
+}


### PR DESCRIPTION
This PR disables dependency pinning in package.json and tells renovate to only create PR:s for security updates.